### PR TITLE
Added `clean` and `test` scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "build": "webpack --config webpack.config.js",
     "build-watch": "webpack --watch --config webpack.config.js",
-    "dev-server": "webpack-dev-server --config webpack.config.js"
+    "dev-server": "webpack-dev-server --config webpack.config.js",
+    "clean": "rm -r dist/*",
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
@mbebenita Added `clean` and `test` scripts.
May be  the error is due to some build configuration as seems from the log `TS2497: Module '"/home/travis/build/mbebenita/WebAssemblyStudio/node_modules/react-split-pane/index"' resolves to a non-module entity and cannot be imported using this construct` looking into it...
