### PR TITLE
add package-lock.json to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist
 node_modules
+package-lock.json


### PR DESCRIPTION
We don't need to commit this everytime, this will allow us to always test the latest version of our dependencies especially in CI.